### PR TITLE
Fix resource leak

### DIFF
--- a/src/vizceral.jsx
+++ b/src/vizceral.jsx
@@ -134,6 +134,7 @@ class Vizceral extends React.Component {
   }
 
   componentWillUnmount () {
+    this.vizceral.animate = () => {};
     delete this.vizceral;
   }
 


### PR DESCRIPTION
When I repeat to mount and unmount Vizceral component many times, the browser get stuck.

Maybe the following chain of `animate() -> requestAnimationFrame() -> animate() -> ...` does not stop even if Vizceral component is deleted in `componentWillUnmount`.

https://github.com/Netflix/vizceral/blob/848db649b3baea5fd761d79b0f15154a205fb9f4/src/vizceral.js#L755-L772

I think this causes resource leaks and make the browser stuck.
This PR fixes them.